### PR TITLE
Fix bug in Clerk webhook: ensure user creation in Convex DB for email signups without first name

### DIFF
--- a/app/(root)/profile/page.tsx
+++ b/app/(root)/profile/page.tsx
@@ -8,14 +8,13 @@ import PodcastCard from "@/components/PodcastCard";
 import ProfileCard from "@/components/ProfileCard";
 import { api } from "@/convex/_generated/api";
 import { ProfilePodcastProps } from "@/types";
-import { useClerk } from "@clerk/nextjs";
 
 const MyProfilePage = () => {
 
-  const { user } = useClerk();
+  const user = useQuery(api.users.getUser);
 
   const podcastsData = useQuery(api.podcasts.getPodcastByAuthorId, {
-    authorId: user?.id!,
+    authorId: user?.clerkId!,
   }) as ProfilePodcastProps;
 
   if (!user || !podcastsData) return <LoaderSpinner />;
@@ -27,10 +26,10 @@ const MyProfilePage = () => {
       </h1>
       <div className="mt-6 flex flex-col gap-6 max-md:items-center md:flex-row">
         <ProfileCard
-          profileId={user.id}
+          profileId={user.clerkId}
           podcastData={podcastsData}
           imageUrl={user?.imageUrl!}
-          userFirstName={user.firstName!}
+          userFirstName={user.name}
         />
       </div>
       <section className="mt-9 flex flex-col gap-5">

--- a/components/RightSidebar.tsx
+++ b/components/RightSidebar.tsx
@@ -27,7 +27,11 @@ const RightSidebar = () => {
         <Link href={`/profile/${user?.id}`} className="flex gap-3 pb-12">
           <UserButton />
           <div className="flex w-full items-center justify-between">
-            <h1 className="text-16 truncate font-semibold text-white-1">{user?.firstName} {user?.lastName}</h1>
+            <h1 className="text-16 truncate font-semibold text-white-1">
+              { user?.firstName && user?.lastName ?
+                user?.firstName + " " + user?.lastName
+              : user?.emailAddresses[0].emailAddress.split("@")[0]}
+            </h1>
             <Image
               src="/icons/right-arrow.svg"
               alt="arrow"

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -20,7 +20,9 @@ const handleClerkWebhook = httpAction(async (ctx, request) => {
         clerkId: event.data.id,
         email: event.data.email_addresses[0].email_address,
         imageUrl: event.data.image_url,
-        name: event.data.first_name!,
+        name: event.data.first_name
+          ? event.data.first_name + " " + (event.data.last_name ?? "")
+          : event.data.email_addresses[0].email_address.split("@")[0],
       });
       break;
     case "user.updated":


### PR DESCRIPTION
### Pull Request Description

**Bug Fix**: Ensure User Creation in Convex DB for Clerk Email Signups Without First Name

This PR addresses a critical bug in the Clerk webhook where users signing up with only an email and no provided first name were not being created in the Convex database. The issue stemmed from a forced assertion (`event.data.first_name!`) on the `first_name` field, which caused an error when `first_name` was null or undefined, halting user creation.

### Changes

- **Before**:
  ```javascript
  name: event.data.first_name!
  ```
  This code assumed that `first_name` was always provided, causing issues when `first_name` was missing.

- **After**:
  ```javascript
  name: event.data.first_name
    ? event.data.first_name + " " + (event.data.last_name ?? "")
    : event.data.email_addresses[0].email_address.split("@")[0]
  ```
  Now, if `first_name` is missing, the code assigns `name` to the username derived from the email prefix. This ensures that all users, even those signing up without a first name, are created in the database.

This fix provides a fallback mechanism for `name`, improving robustness and ensuring successful user creation for all signups.